### PR TITLE
chore: Rename package to io.ionic.libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ This library is used by the Geolocation Plugin for [OutSystems' Cordova Plugin](
 
 In your app-level gradle file, import the `OSGeolocationLib` library like so:
 
+```
     dependencies {
-    	implementation("com.capacitorjs:osgeolocation-android:1.0.0")
+    	implementation("io.ionic.libs:osgeolocation-android:1.0.0")
 	}
-
+```
 
 ## Methods
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply plugin: "kotlin-android"
 apply plugin: "jacoco"
 
 android {
-    namespace "com.outsystems.plugins.osgeolocation"
+    namespace "io.ionic.libs.osgeolocationlib"
     compileSdk 35
 
     defaultConfig {

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
-package_name("com.outsystems.plugins.osgeolocation.osgeolocationlib") # e.g. com.krausefx.app
+package_name("io.ionic.libs.osgeolocationlib") # e.g. com.krausefx.app

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
              http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.outsystems</groupId>
+    <groupId>io.ionic.libs</groupId>
     <artifactId>osgeolocation-android</artifactId>
     <version>0.0.1</version>
 </project>

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -42,7 +42,7 @@ afterEvaluate {
                     licenses {
                         license {
                             name = 'License'
-                            url = 'https://github.com/ionic-team/OSGeolocationLib-Android/blob/main/docs/LICENSE'
+                            url = 'https://github.com/ionic-team/OSGeolocationLib-Android/blob/main/LICENSE'
                         }
                     }
                     developers {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.outsystems.plugins.osgeolocation">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCBuildConfig.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCBuildConfig.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.controller
+package io.ionic.libs.osgeolocationlib.controller
 
 import android.os.Build
 

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCController.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCController.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.controller
+package io.ionic.libs.osgeolocationlib.controller
 
 import android.app.Activity
 import android.content.Context
@@ -12,9 +12,9 @@ import androidx.core.location.LocationManagerCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationResult
-import com.outsystems.plugins.osgeolocation.model.OSGLOCException
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationOptions
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationResult
+import io.ionic.libs.osgeolocationlib.model.OSGLOCException
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationOptions
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationResult
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCServiceHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/controller/OSGLOCServiceHelper.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.controller
+package io.ionic.libs.osgeolocationlib.controller
 
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -16,8 +16,8 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.Priority
-import com.outsystems.plugins.osgeolocation.model.OSGLOCException
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationOptions
+import io.ionic.libs.osgeolocationlib.model.OSGLOCException
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationOptions
 import kotlinx.coroutines.tasks.await
 
 /**

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCException.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCException.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.model
+package io.ionic.libs.osgeolocationlib.model
 
 /**
  * Sealed class with exceptions that the library's functions can throw

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCLocationOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCLocationOptions.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.model
+package io.ionic.libs.osgeolocationlib.model
 
 /**
  * Data class representing the options passed to getCurrentPosition and watchPosition

--- a/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCLocationResult.kt
+++ b/src/main/kotlin/io/ionic/libs/osgeolocationlib/model/OSGLOCLocationResult.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.model
+package io.ionic.libs.osgeolocationlib.model
 
 /**
  * Data class representing the object returned in getCurrentPosition and watchPosition

--- a/src/test/java/io/ionic/libs/osgeolocationlib/controller/OSGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/osgeolocationlib/controller/OSGLOCControllerTest.kt
@@ -1,4 +1,4 @@
-package com.outsystems.plugins.osgeolocation.controller
+package io.ionic.libs.osgeolocationlib.controller
 
 import android.app.Activity
 import android.app.PendingIntent
@@ -22,9 +22,9 @@ import com.google.android.gms.location.LocationSettingsResponse
 import com.google.android.gms.location.LocationSettingsResult
 import com.google.android.gms.location.SettingsClient
 import com.google.android.gms.tasks.Task
-import com.outsystems.plugins.osgeolocation.model.OSGLOCException
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationOptions
-import com.outsystems.plugins.osgeolocation.model.OSGLOCLocationResult
+import io.ionic.libs.osgeolocationlib.model.OSGLOCException
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationOptions
+import io.ionic.libs.osgeolocationlib.model.OSGLOCLocationResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
## Description

Refactor the package name to use `io.ionic.libs`. 

The capacitor and cordova plugin repos will be updated as well.

## Context

This lib will be published under `io.ionic.libs` instead of `com.capacitorjs` or `com.outsystems.plugins`

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [X] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
