### PR TITLE
feat!: Fallback for no network or Play Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0]
+
+### 2025-09-30
+
+- Feature: Allow using a fallback if Google Play Services fails.
+
+BREAKING CHANGE: The constructor for the controller and some of its methods have changed signature.
+You will need to change how your application calls the library if you update to this version.
 
 ### 2025-06-26
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Common issues and solutions:
    - Ensure clear sky view
    - Wait for better GPS signal
 
+3. Error received when in airplane mode
+   - Try setting `IONGLOCLocationOptions.enableLocationManagerFallback` to true - available since version 2.0.0
+   - Keep in mind that only GPS signal can be used if there's no network, in which case it may only be triggered if the actual GPS coordinates are changing (e.g. walking or driving).
+
 ## Contributing
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your app-level gradle file, import the `ion-android-geolocation` library like
 
 ```
     dependencies {
-    	implementation("io.ionic.libs:iongeolocation-android:1.0.0")
+    	implementation("io.ionic.libs:iongeolocation-android:2.0.0")
 	}
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         if (System.getenv("SHOULD_PUBLISH") == "true") {
             classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         }
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.12.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
     }
@@ -41,11 +41,11 @@ apply plugin: "jacoco"
 
 android {
     namespace "io.ionic.libs.iongeolocationlib"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         minSdk 23
-        targetSdk 35
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 08 08:58:08 WEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>iongeolocation-android</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 </project>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -12,11 +12,6 @@
 - [ ] Refactor (cosmetic changes)
 - [ ] Breaking change (change that would cause existing functionality to not work as expected)
 
-## Platforms affected
-- [ ] Android
-- [ ] iOS
-- [ ] JavaScript
-
 ## Tests
 <!--- Describe how you tested your changes in detail -->
 <!--- Include details of your test environment if relevant -->

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.location.Location
 import android.location.LocationManager
+import android.net.ConnectivityManager
 import android.os.Build
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
@@ -33,12 +34,15 @@ import kotlinx.coroutines.flow.first
 class IONGLOCController internal constructor(
     fusedLocationClient: FusedLocationProviderClient,
     private val locationManager: LocationManager,
+    connectivityManager: ConnectivityManager,
     activityLauncher: ActivityResultLauncher<IntentSenderRequest>,
     private val googleServicesHelper: IONGLOCGoogleServicesHelper = IONGLOCGoogleServicesHelper(
         fusedLocationClient,
         activityLauncher
     ),
-    private val fallbackHelper: IONGLOCFallbackHelper = IONGLOCFallbackHelper(locationManager)
+    private val fallbackHelper: IONGLOCFallbackHelper = IONGLOCFallbackHelper(
+        locationManager, connectivityManager
+    )
 ) {
 
     constructor(
@@ -47,6 +51,7 @@ class IONGLOCController internal constructor(
     ) : this(
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(context),
         locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager,
+        connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager,
         activityLauncher = activityLauncher
     )
 

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
@@ -68,12 +68,12 @@ class IONGLOCController internal constructor(
         try {
             val checkResult: Result<Unit> =
                 checkLocationPreconditions(activity, options, isSingleLocationRequest = true)
-            return if (checkResult.isFailure && !options.useLocationManagerFallback) {
+            return if (checkResult.isFailure && !options.enableLocationManagerFallback) {
                 Result.failure(
                     checkResult.exceptionOrNull() ?: NullPointerException()
                 )
             } else {
-                val location: Location = if (!options.useLocationManagerFallback) {
+                val location: Location = if (!options.enableLocationManagerFallback) {
                     googleServicesHelper.getCurrentLocation(options)
                 } else {
                     fallbackHelper.getCurrentLocation()
@@ -130,19 +130,19 @@ class IONGLOCController internal constructor(
                 if (checkWatchInBlackList(watchId)) {
                     return
                 }
-                val locations = locations.map { currentLocation ->
+                val locationResultList = locations.map { currentLocation ->
                     currentLocation.toOSLocationResult()
                 }
-                trySend(Result.success(locations))
+                trySend(Result.success(locationResultList))
             }
             val checkResult: Result<Unit> =
                 checkLocationPreconditions(activity, options, isSingleLocationRequest = true)
-            if (checkResult.isFailure && !options.useLocationManagerFallback) {
+            if (checkResult.isFailure && !options.enableLocationManagerFallback) {
                 trySend(
                     Result.failure(checkResult.exceptionOrNull() ?: NullPointerException())
                 )
             } else {
-                watchLocationHandlers[watchId] = if (!options.useLocationManagerFallback) {
+                watchLocationHandlers[watchId] = if (!options.enableLocationManagerFallback) {
                     LocationHandler.Callback(object : LocationCallback() {
                         override fun onLocationResult(location: LocationResult) {
                             onNewLocations(location.locations)
@@ -204,9 +204,9 @@ class IONGLOCController internal constructor(
         }
         // if meant to use fallback, then resolvable errors from Play Services Location don't need to be addressed
         val playServicesResult = googleServicesHelper.checkGooglePlayServicesAvailable(
-            activity, shouldTryResolve = !options.useLocationManagerFallback
+            activity, shouldTryResolve = !options.enableLocationManagerFallback
         )
-        if (playServicesResult.isFailure && !options.useLocationManagerFallback) {
+        if (playServicesResult.isFailure && !options.enableLocationManagerFallback) {
             return Result.failure(playServicesResult.exceptionOrNull() ?: NullPointerException())
         }
 
@@ -215,7 +215,7 @@ class IONGLOCController internal constructor(
             activity,
             locationManager,
             options.copy(timeout = if (isSingleLocationRequest) 0 else options.timeout),
-            shouldTryResolve = !options.useLocationManagerFallback
+            shouldTryResolve = !options.enableLocationManagerFallback
         )
 
         return when (locationSettingsResult) {

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCBuildConfig.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCBuildConfig.kt
@@ -1,4 +1,4 @@
-package io.ionic.libs.iongeolocationlib.controller
+package io.ionic.libs.iongeolocationlib.controller.helper
 
 import android.os.Build
 

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
@@ -1,0 +1,62 @@
+package io.ionic.libs.iongeolocationlib.controller.helper
+
+import android.location.Location
+import android.location.LocationManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import androidx.core.location.LocationManagerCompat
+import io.ionic.libs.iongeolocationlib.model.IONGLOCException
+import io.ionic.libs.iongeolocationlib.model.IONGLOCLocationResult
+
+/**
+ * @return true if there's any active network capability that could be used to improve location, false otherwise.
+ */
+internal fun hasNetworkEnabledForLocationPurposes(
+    locationManager: LocationManager,
+    connectivityManager: ConnectivityManager
+) = LocationManagerCompat.hasProvider(locationManager, LocationManager.NETWORK_PROVIDER) &&
+        connectivityManager.activeNetwork?.let { network ->
+            connectivityManager.getNetworkCapabilities(network)?.let { capabilities ->
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ||
+                        (IONGLOCBuildConfig.getAndroidSdkVersionCode() >= Build.VERSION_CODES.O &&
+                                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE))
+            }
+        } ?: false
+
+/**
+ * Returns a Result object containing an IONGLOCException.IONGLOCGoogleServicesException exception with the given
+ * resolvable and message values
+ * @param resolvable whether or not the exception is resolvable
+ * @param message message to include in the exception
+ * @return Result object with the exception to return
+ *
+ */
+internal fun sendResultWithGoogleServicesException(
+    resolvable: Boolean,
+    message: String
+): Result<Unit> {
+    return Result.failure(
+        IONGLOCException.IONGLOCGoogleServicesException(
+            resolvable = resolvable,
+            message = message
+        )
+    )
+}
+
+/**
+ * Extension function to convert Location object into OSLocationResult object
+ * @return OSLocationResult object
+ */
+internal fun Location.toOSLocationResult(): IONGLOCLocationResult = IONGLOCLocationResult(
+    latitude = this.latitude,
+    longitude = this.longitude,
+    altitude = this.altitude,
+    accuracy = this.accuracy,
+    altitudeAccuracy = if (IONGLOCBuildConfig.getAndroidSdkVersionCode() >= Build.VERSION_CODES.O) this.verticalAccuracyMeters else null,
+    heading = this.bearing,
+    speed = this.speed,
+    timestamp = this.time
+)

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCFallbackHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCFallbackHelper.kt
@@ -1,0 +1,93 @@
+package io.ionic.libs.iongeolocationlib.controller.helper
+
+import android.annotation.SuppressLint
+import android.location.Location
+import android.location.LocationManager
+import android.os.CancellationSignal
+import android.os.Looper
+import androidx.core.location.LocationListenerCompat
+import androidx.core.location.LocationManagerCompat
+import androidx.core.location.LocationRequestCompat
+import io.ionic.libs.iongeolocationlib.model.IONGLOCException
+import io.ionic.libs.iongeolocationlib.model.IONGLOCLocationOptions
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Helper class that wraps the functionality of Android's [LocationManager].
+ * Meant to be used only as a fallback in case we cannot used the Fused Location Provider from Play Services.
+ */
+internal class IONGLOCFallbackHelper(
+    private val locationManager: LocationManager
+) {
+    /**
+     * Obtains a fresh device location.
+     * This fallback method does not receive options because Android API does not allow to configure specific options.
+     * @return Location object representing the location
+     */
+    @SuppressLint("MissingPermission")
+    internal suspend fun getCurrentLocation(): Location =
+        suspendCancellableCoroutine { continuation ->
+            val cancellationSignal: CancellationSignal? = null
+            LocationManagerCompat.getCurrentLocation(
+                locationManager,
+                LocationManager.GPS_PROVIDER,
+                cancellationSignal,
+                Executors.newSingleThreadExecutor()
+            ) { location ->
+                if (location != null) {
+                    continuation.resume(location)
+                } else {
+                    continuation.resumeWithException(
+                        IONGLOCException.IONGLOCLocationRetrievalTimeoutException(
+                            message = "Location request timed out"
+                        )
+                    )
+                }
+            }
+        }
+
+    /**
+     * Requests updates of device location.
+     *
+     * Locations returned in callback associated with watchId
+     * @param options location request options to use
+     * @param locationListener the [LocationListenerCompat] to receive location updates in
+     */
+    @SuppressLint("MissingPermission")
+    internal fun requestLocationUpdates(
+        options: IONGLOCLocationOptions,
+        locationListener: LocationListenerCompat
+    ) {
+        val locationRequest = LocationRequestCompat.Builder(options.timeout).apply {
+            // note: setMaxUpdateAgeMillis unavailable in this API, so options.maximumAge is not used
+            setQuality(if (options.enableHighAccuracy) LocationRequestCompat.QUALITY_HIGH_ACCURACY else LocationRequestCompat.QUALITY_BALANCED_POWER_ACCURACY)
+            if (options.minUpdateInterval != null) {
+                setMinUpdateIntervalMillis(options.minUpdateInterval)
+            }
+        }.build()
+
+        LocationManagerCompat.requestLocationUpdates(
+            locationManager,
+            LocationManager.GPS_PROVIDER,
+            locationRequest,
+            locationListener,
+            Looper.getMainLooper()
+        )
+    }
+
+    /**
+     * Remove location updates for a specific listener.
+     *
+     * This method only triggers the removal, it does not await to see if the listener was actually removed.
+     *
+     * @param locationListener the location listener to be removed
+     */
+    internal fun removeLocationUpdates(
+        locationListener: LocationListenerCompat
+    ) {
+        LocationManagerCompat.removeUpdates(locationManager, locationListener)
+    }
+}

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
@@ -20,6 +20,7 @@ import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.Priority
 import io.ionic.libs.iongeolocationlib.model.IONGLOCException
 import io.ionic.libs.iongeolocationlib.model.IONGLOCLocationOptions
+import io.ionic.libs.iongeolocationlib.model.internal.LocationSettingsResult
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -115,26 +116,6 @@ internal class IONGLOCGoogleServicesHelper(
     }
 
     /**
-     * Returns a Result object containing an IONGLOCException.IONGLOCGoogleServicesException exception with the given
-     * resolvable and message values
-     * @param resolvable whether or not the exception is resolvable
-     * @param message message to include in the exception
-     * @return Result object with the exception to return
-     *
-     */
-    private fun sendResultWithGoogleServicesException(
-        resolvable: Boolean,
-        message: String
-    ): Result<Unit> {
-        return Result.failure(
-            IONGLOCException.IONGLOCGoogleServicesException(
-                resolvable = resolvable,
-                message = message
-            )
-        )
-    }
-
-    /**
      * Obtains a fresh device location.
      * @param options location request options to use
      * @return Location object representing the location
@@ -192,33 +173,5 @@ internal class IONGLOCGoogleServicesHelper(
         locationCallback: LocationCallback
     ) {
         fusedLocationClient.removeLocationUpdates(locationCallback)
-    }
-
-    /**
-     * Result returned from checking Location Settings
-     */
-    internal sealed class LocationSettingsResult {
-        /**
-         * Location settings checked successfully - Able to request location via Google Play Services
-         */
-        data object Success : LocationSettingsResult()
-
-        /**
-         * Received an error from location settings that may be resolved by the user.
-         * Check `resolveLocationSettingsResultFlow` in `IONGLOCController` to receive this result
-         */
-        data object Resolving : LocationSettingsResult()
-
-        /**
-         * Received a resolvable error from location settings, but resolving was skipped.
-         * Check the docs on `checkLocationSettings` for more information
-         */
-        data class ResolveSkipped(val resolvableError: ResolvableApiException) :
-            LocationSettingsResult()
-
-        /**
-         * An unresolvable error occurred - Cannot request location via Google Play Services
-         */
-        data class UnresolvableError(val error: Exception) : LocationSettingsResult()
     }
 }

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
@@ -37,7 +37,6 @@ internal class IONGLOCGoogleServicesHelper(
     /**
      * Checks if location is on, as well as other conditions for retrieving device location
      * @param activity the Android activity from which the location request is being triggered
-     * @param locationManager the [LocationManager] to get additional location settings from
      * @param options location request options to use
      * @param shouldTryResolve true if should try to resolve errors; false otherwise.
      * Dictates whether [LocationSettingsResult.Resolving] or [LocationSettingsResult.ResolveSkipped] is returned.

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCException.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCException.kt
@@ -20,4 +20,7 @@ sealed class IONGLOCException(message: String, cause: Throwable?) : Exception(me
     class IONGLOCLocationRetrievalTimeoutException(
         message: String, cause: Throwable? = null
     ) : IONGLOCException(message, cause)
+    class IONGLOCLocationAndNetworkDisabledException(
+        message: String, cause: Throwable? = null
+    ) : IONGLOCException(message, cause)
 }

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
@@ -7,6 +7,6 @@ data class IONGLOCLocationOptions(
     val timeout: Long,
     val maximumAge: Long,
     val enableHighAccuracy: Boolean,
-    val useLocationManagerFallback: Boolean,
+    val enableLocationManagerFallback: Boolean,
     val minUpdateInterval: Long? = null,
 )

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
@@ -7,5 +7,6 @@ data class IONGLOCLocationOptions(
     val timeout: Long,
     val maximumAge: Long,
     val enableHighAccuracy: Boolean,
-    val minUpdateInterval: Long? = null
+    val useLocationManagerFallback: Boolean,
+    val minUpdateInterval: Long? = null,
 )

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
@@ -2,6 +2,27 @@ package io.ionic.libs.iongeolocationlib.model
 
 /**
  * Data class representing the options passed to getCurrentPosition and watchPosition
+ *
+ * @property timeout Depending on the method:
+ *  1. for `getCurrentPosition`, it's the maximum time in **milliseconds** to wait for a fresh
+ *      location fix before throwing a timeout exception.
+ *  2. for `addWatch` the interval at which new location updates will be returned (if available)
+ * @property maximumAge Maximum acceptable age in **milliseconds** of a cached location to return.
+ *  If the cached location is older than this value, then a fresh location will always be fetched.
+ * @property enableHighAccuracy Whether or not the requested location should have high accuracy.
+ *  Note that high accuracy requests may increase power/battery consumption.
+ * @property enableLocationManagerFallback Whether to fall back to the Android framework's
+ *  [android.location.LocationManager] APIs in case [com.google.android.gms.location.FusedLocationProviderClient]
+ *  location settings checks fail.
+ *  This can happen for multiple reasons, e.g. Google Play Services location APIs are unavailable
+ *      or device has no Network connection (e.g. on Airplane mode).
+ *  If set to `false`, failures will propagate as exceptions instead of falling back.
+ *  Note that [android.location.LocationManager] may not be as effective as Google Play Services implementation.
+ *  This means that to receive location, you may need a higher timeout.
+ *  If the device's in airplane mode, only the GPS provider is used, which may only return a location
+ *      if there's movement (e.g. walking or driving), otherwise it may time out.
+ * @property minUpdateInterval Optional minimum interval in **milliseconds** between consecutive
+ *  location updates when using `addWatch`.
  */
 data class IONGLOCLocationOptions(
     val timeout: Long,

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/internal/LocationHandler.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/internal/LocationHandler.kt
@@ -1,0 +1,19 @@
+package io.ionic.libs.iongeolocationlib.model.internal
+
+import androidx.core.location.LocationListenerCompat
+import com.google.android.gms.location.LocationCallback
+
+/**
+ * Handler for receiving location updates, the implementation depends on if Play Services or Fallback is used
+ */
+sealed class LocationHandler {
+    /**
+     * Location updates returned via Google Play Service's [LocationCallback]
+     */
+    data class Callback(val callback: LocationCallback) : LocationHandler()
+
+    /**
+     * Location updates returned via fallback [android.location.LocationManager] with [LocationListenerCompat]
+     */
+    data class Listener(val listener: LocationListenerCompat) : LocationHandler()
+}

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/internal/LocationSettingsResult.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/internal/LocationSettingsResult.kt
@@ -1,0 +1,31 @@
+package io.ionic.libs.iongeolocationlib.model.internal
+
+import com.google.android.gms.common.api.ResolvableApiException
+
+/**
+ * Result returned from checking Location Settings
+ */
+internal sealed class LocationSettingsResult {
+    /**
+     * Location settings checked successfully - Able to request location via Google Play Services
+     */
+    data object Success : LocationSettingsResult()
+
+    /**
+     * Received an error from location settings that may be resolved by the user.
+     * Check `resolveLocationSettingsResultFlow` in `IONGLOCController` to receive this result
+     */
+    data object Resolving : LocationSettingsResult()
+
+    /**
+     * Received a resolvable error from location settings, but resolving was skipped.
+     * Check the docs on `checkLocationSettings` for more information
+     */
+    data class ResolveSkipped(val resolvableError: ResolvableApiException) :
+        LocationSettingsResult()
+
+    /**
+     * An unresolvable error occurred - Cannot request location via Google Play Services
+     */
+    data class UnresolvableError(val error: Exception) : LocationSettingsResult()
+}

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -382,7 +382,7 @@ class IONGLOCControllerTest {
 
     // region fallback tests
     @Test
-    fun `given location settings check fails but useLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
+    fun `given location settings check fails but enableLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
         runTest {
             givenSuccessConditions() // to instantiate mocks
             val error = RuntimeException()
@@ -395,7 +395,7 @@ class IONGLOCControllerTest {
         }
 
     @Test
-    fun `given location settings check fails with resolvableError but useLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
+    fun `given location settings check fails with resolvableError but enableLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
         runTest {
             givenSuccessConditions() // to instantiate mocks
             givenResolvableApiException(Activity.RESULT_OK)
@@ -407,7 +407,7 @@ class IONGLOCControllerTest {
         }
 
     @Test
-    fun `given location settings check fails with resolvableError, location is off, and useLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
+    fun `given location settings check fails with resolvableError, location is off, and enableLocationManagerFallback=true, when getCurrentLocation is called, result is returned`() =
         runTest {
             givenSuccessConditions() // to instantiate mocks
             givenResolvableApiException(Activity.RESULT_OK)
@@ -421,7 +421,7 @@ class IONGLOCControllerTest {
         }
 
     @Test
-    fun `given play services not available but useLocationManagerFallback=true, when addWatch is called, locations returned in flow`() =
+    fun `given play services not available but enableLocationManagerFallback=true, when addWatch is called, locations returned in flow`() =
         runTest {
             givenSuccessConditions()
             givenPlayServicesNotAvailableWithResolvableError()
@@ -587,11 +587,11 @@ class IONGLOCControllerTest {
             maximumAge = 3000,
             enableHighAccuracy = true,
             minUpdateInterval = 2000L,
-            useLocationManagerFallback = false
+            enableLocationManagerFallback = false
         )
 
         private val locationOptionsWithFallback =
-            locationOptions.copy(useLocationManagerFallback = true)
+            locationOptions.copy(enableLocationManagerFallback = true)
 
         private val locationResult = IONGLOCLocationResult(
             latitude = 1.0,

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -596,6 +596,7 @@ class IONGLOCControllerTest {
         every { fusedLocationProviderClient.removeLocationUpdates(any<LocationCallback>()) } returns voidTask
 
         every { connectivityManager.activeNetwork } returns null
+        every { LocationManagerCompat.hasProvider(any(), any()) } returns true
         every { LocationManagerCompat.isLocationEnabled(any()) } returns true
         every { locationManager.getLastKnownLocation(any()) } returns null
         val consumerSlot = slot<Consumer<Location>>()

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -528,6 +528,29 @@ class IONGLOCControllerTest {
         }
 
     @Test
+    fun `given play services not available but enableLocationManagerFallback=true and there is cached location, when addWatch is called, cached location returned in flow`() =
+        runTest {
+            givenSuccessConditions()
+            givenPlayServicesNotAvailableWithUnResolvableError()
+            val currentTime = System.currentTimeMillis()
+            every { locationManager.getLastKnownLocation(any()) } returns mockkLocation {
+                every { time } returns currentTime
+            }
+
+            sut.addWatch(mockk<Activity>(), locationOptionsWithFallback, "1").test {
+                advanceUntilIdle()  // to wait until locationListenerCompat is instantiated
+
+                val result = awaitItem()
+                assertTrue(result.isSuccess)
+                assertEquals(
+                    listOf(locationResult.copy(timestamp = currentTime)),
+                    result.getOrNull()
+                )
+                expectNoEvents()
+            }
+        }
+
+    @Test
     fun `given watch was added via fallback, when clearWatch is called, true is returned`() =
         runTest {
             val watchId = "id"


### PR DESCRIPTION
## Description

This PR provides a new option `enableLocationManagerFallback` for using Android Framework's [LocationManager](https://developer.android.com/reference/android/location/LocationManager), if for some reason using the Fused Provider from GMS is not possible (e.g. device without Play Services).

Also using the `LocationManager` with `enableLocationManagerFallback=true` when there's no network (e.g. device in Airplane mode). Even though Fused Provider technically could work without network (it would just use GPS), the location settings check fails - in this situation we use `LocationManager` with just GPS provider.

This PR contains BREAKING CHANGE: The constructor for the controller and some of its methods have changed signature.
Clients will need to change how your application calls the library if you update to this version.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-2991

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [X] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Use the following application, either [from .apk file](https://drive.google.com/file/d/1hltlShajBFFR23JsCePeL_xOzQLVcv4-/view?usp=sharing) or build from [source code](https://drive.google.com/file/d/1SZW26kq4PGPrNG41fJdqvTYmn57WKWC1/view?usp=sharing) (downloads may take a few seconds to start) - It's the Location Sample App From OutSystems O11 but with code from this PR in the native library.

### Testing with airplane mode

If you set the device to airplane mode, it will use the `LocationManager` fallback.

Depending on what device you're testing, you may get location timeouts. This is because there is only GPS to access, which may be slower or in some cases only return a location when there's actual movement.

- Try setting a higher timeout value, and to check that cached locations are still returned, try increasing maximum age.
- For emulators - If you use the extended controls (three vertical dots), you'll be able to set new GPS coordinates, which should help in triggering new location updates.
- For physical devices
    - On a Pixel I was able to trigger this fairly often by shaking the phone quickly
    - On another device I was only able to trigger updates when walking outside, so that GPS would update

### Testing without Play Services

You may test with an emulator and AOSP image (without Play Store). Other than that I saw a "Huawei P40" on sauce labs, but it didn't have Petal Maps installed, the only way I found to properly trigger a new location was via the Sauce Labs Tools to mock a different device location.


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
