### PR TITLE
feat: Separate timeout from interval in location watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0]
+
+### 2025-10-31
+
+- Feature: Add native timeout to `watchPosition` Add new `interval` to control location updates without `timeout` variable.
+
 ## [2.0.0]
 
 ### 2025-09-30

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Common issues and solutions:
    - Try setting `IONGLOCLocationOptions.enableLocationManagerFallback` to true - available since version 2.0.0
    - Keep in mind that only GPS signal can be used if there's no network, in which case it may only be triggered if the actual GPS coordinates are changing (e.g. walking or driving).
 
+4. Timeout received in `watchPosition`
+    - Use the `IONGLOCLocationOptions.interval` parameter, introduced in version 2.1.0, and set it to below `timeout`, in order to try to receive a first location update before timing out.
+    - Increase the `IONGLOCLocationOptions.timeout` value, if your use case can wait for some time.
+    - Increase `IONGLOCLocationOptions.maximumAge` to allow to retrieve an older location quickly for the first update.
+
 ## Contributing
 
 1. Fork the repository

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In your app-level gradle file, import the `ion-android-geolocation` library like
 
 ```
     dependencies {
-    	implementation("io.ionic.libs:iongeolocation-android:2.0.0")
+    	implementation("io.ionic.libs:iongeolocation-android:2.1.0")
 	}
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,5 +6,5 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.ionic.libs</groupId>
     <artifactId>iongeolocation-android</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </project>

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/IONGLOCController.kt
@@ -160,7 +160,7 @@ class IONGLOCController internal constructor(
                     .emitOrTimeoutBeforeFirstEmission(timeoutMillis = options.timeout)
                     .onEach { emission ->
                         if (emission.exceptionOrNull() is IONGLOCException.IONGLOCLocationRetrievalTimeoutException) {
-                            watchIdsBlacklist.add(watchId)
+                            clearWatch(watchId)
                         }
                     }
             }

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
@@ -8,11 +8,11 @@ import android.os.Build
 import androidx.core.location.LocationManagerCompat
 import io.ionic.libs.iongeolocationlib.model.IONGLOCException
 import io.ionic.libs.iongeolocationlib.model.IONGLOCLocationResult
-import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * @return true if there's any active network capability that could be used to improve location, false otherwise.
@@ -70,22 +70,29 @@ internal fun Location.toOSLocationResult(): IONGLOCLocationResult = IONGLOCLocat
  * Flow extension to either emit its values, or emit a timeout error if [timeoutMillis] is reached before any emission
  */
 fun <T> Flow<Result<T>>.emitOrTimeoutBeforeFirstEmission(timeoutMillis: Long): Flow<Result<T>> =
-    flow {
-        // Wait for the first emission with timeout
-        val firstValue = try {
-            withTimeout(timeoutMillis) { first() }
-        } catch (e: TimeoutCancellationException) {
-            emit(
+    channelFlow {
+        var firstValue: Result<T>? = null
+
+        val job = launch {
+            collect { value ->
+                if (firstValue == null) firstValue = value
+                send(value)
+            }
+        }
+
+        // Poll until first emission, or timeout
+        withTimeoutOrNull(timeMillis = timeoutMillis) {
+            while (firstValue == null) {
+                delay(timeMillis = 10)
+            }
+        } ?: run {
+            send(
                 Result.failure(
                     IONGLOCException.IONGLOCLocationRetrievalTimeoutException(
-                        "Location request timed out before first emission",
-                        e
+                        "Location request timed out before first emission"
                     )
                 )
             )
-            return@flow
+            job.cancel()
         }
-
-        emit(firstValue)
-        collect { if (it != firstValue) emit(it) }
     }

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCExtensions.kt
@@ -67,7 +67,7 @@ internal fun Location.toOSLocationResult(): IONGLOCLocationResult = IONGLOCLocat
 )
 
 /**
- *
+ * Flow extension to either emit its values, or emit a timeout error if [timeoutMillis] is reached before any emission
  */
 fun <T> Flow<Result<T>>.emitOrTimeoutBeforeFirstEmission(timeoutMillis: Long): Flow<Result<T>> =
     flow {

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCFallbackHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCFallbackHelper.kt
@@ -94,7 +94,7 @@ internal class IONGLOCFallbackHelper(
             locationListener.onLocationChanged(validCacheLocation)
         }
 
-        val locationRequest = LocationRequestCompat.Builder(options.timeout).apply {
+        val locationRequest = LocationRequestCompat.Builder(options.interval).apply {
             setQuality(getQualityToUse(options))
             if (options.minUpdateInterval != null) {
                 setMinUpdateIntervalMillis(options.minUpdateInterval)

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/controller/helper/IONGLOCGoogleServicesHelper.kt
@@ -51,7 +51,7 @@ internal class IONGLOCGoogleServicesHelper(
     ): LocationSettingsResult {
         val request = LocationRequest.Builder(
             if (options.enableHighAccuracy) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-            options.timeout
+            options.interval
         ).build()
 
         val builder = LocationSettingsRequest.Builder()
@@ -144,7 +144,7 @@ internal class IONGLOCGoogleServicesHelper(
         options: IONGLOCLocationOptions,
         locationCallback: LocationCallback
     ) {
-        val locationRequest = LocationRequest.Builder(options.timeout).apply {
+        val locationRequest = LocationRequest.Builder(options.interval).apply {
             setMaxUpdateAgeMillis(options.maximumAge)
             setPriority(if (options.enableHighAccuracy) Priority.PRIORITY_HIGH_ACCURACY else Priority.PRIORITY_BALANCED_POWER_ACCURACY)
             if (options.minUpdateInterval != null) {

--- a/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
+++ b/src/main/kotlin/io/ionic/libs/iongeolocationlib/model/IONGLOCLocationOptions.kt
@@ -3,10 +3,8 @@ package io.ionic.libs.iongeolocationlib.model
 /**
  * Data class representing the options passed to getCurrentPosition and watchPosition
  *
- * @property timeout Depending on the method:
- *  1. for `getCurrentPosition`, it's the maximum time in **milliseconds** to wait for a fresh
- *      location fix before throwing a timeout exception.
- *  2. for `addWatch` the interval at which new location updates will be returned (if available)
+ * @property timeout The maximum time in **milliseconds** to wait for a new location fix before
+ *  throwing a timeout exception.
  * @property maximumAge Maximum acceptable age in **milliseconds** of a cached location to return.
  *  If the cached location is older than this value, then a fresh location will always be fetched.
  * @property enableHighAccuracy Whether or not the requested location should have high accuracy.
@@ -21,6 +19,9 @@ package io.ionic.libs.iongeolocationlib.model
  *  This means that to receive location, you may need a higher timeout.
  *  If the device's in airplane mode, only the GPS provider is used, which may only return a location
  *      if there's movement (e.g. walking or driving), otherwise it may time out.
+ * @property interval Default interval in **milliseconds** to receive location updates in `addWatch`.
+ *  By default equal to [timeout]. If you are experiencing location timeouts, try setting
+ *  [interval] to a value lower than [timeout].
  * @property minUpdateInterval Optional minimum interval in **milliseconds** between consecutive
  *  location updates when using `addWatch`.
  */
@@ -29,5 +30,6 @@ data class IONGLOCLocationOptions(
     val maximumAge: Long,
     val enableHighAccuracy: Boolean,
     val enableLocationManagerFallback: Boolean,
+    val interval: Long = timeout,
     val minUpdateInterval: Long? = null,
 )

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -578,9 +577,8 @@ class IONGLOCControllerTest {
                 every { time } returns currentTime
             }
 
-            // call internal method to skip timeout
-            sut.watchLocationUpdatesFlow(locationOptionsWithFallback, "1").test {
-                advanceUntilIdle()
+            sut.addWatch(mockk<Activity>(), locationOptionsWithFallback, "1").test {
+                testScheduler.advanceUntilIdle()
 
                 val result = awaitItem()
                 assertTrue(result.isSuccess)

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -607,6 +607,23 @@ class IONGLOCControllerTest {
         }
 
     @Test
+    fun `given all preconditions pass and enableLocationManagerFallback=true, when addWatch is called, the fallback is not called`() =
+        runTest {
+            givenSuccessConditions() // to instantiate mocks
+
+            sut.addWatch(mockk<Activity>(), locationOptionsWithFallback, "1").test {
+                // to wait until locationListenerCompat is instantiated, but not long enough for timeout to trigger
+                advanceTimeBy(locationOptionsWithFallback.timeout / 2)
+                emitLocationsGMS(listOf(mockAndroidLocation))
+                assertTrue(awaitItem().isSuccess)
+            }
+
+            coVerify(inverse = true) {
+                fallbackHelper.requestLocationUpdates(any(), any())
+            }
+        }
+
+    @Test
     fun `given watch was added via fallback, when clearWatch is called, true is returned`() =
         runTest {
             val watchId = "id"

--- a/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
+++ b/src/test/java/io/ionic/libs/iongeolocationlib/controller/IONGLOCControllerTest.kt
@@ -281,8 +281,7 @@ class IONGLOCControllerTest {
         runTest {
             givenPlayServicesNotAvailableWithResolvableError()
 
-            // skip timeout in tests by calling internal method
-            sut.addWatchInternal(mockk<Activity>(), locationOptions, "1").test {
+            sut.addWatch(mockk<Activity>(), locationOptions, "1").test {
                 val result = awaitItem()
 
                 assertTrue(result.isFailure)
@@ -290,7 +289,7 @@ class IONGLOCControllerTest {
                     assertTrue(exception is IONGLOCException.IONGLOCGoogleServicesException)
                     assertTrue((exception as IONGLOCException.IONGLOCGoogleServicesException).resolvable)
                 }
-                expectNoEvents()
+                awaitComplete()
             }
         }
 
@@ -324,7 +323,7 @@ class IONGLOCControllerTest {
 
                 assertTrue(result.isFailure)
                 assertTrue(result.exceptionOrNull() is IONGLOCException.IONGLOCRequestDeniedException)
-                expectNoEvents()
+                awaitComplete()
             }
         }
 
@@ -335,8 +334,7 @@ class IONGLOCControllerTest {
             val error = RuntimeException()
             coEvery { locationSettingsTask.await() } throws error
 
-            // skip timeout in tests by calling internal method
-            sut.addWatchInternal(mockk<Activity>(), locationOptions, "1").test {
+            sut.addWatch(mockk<Activity>(), locationOptions, "1").test {
                 testScheduler.advanceTimeBy(DELAY)
                 val result = awaitItem()
 
@@ -348,7 +346,7 @@ class IONGLOCControllerTest {
                         (exception as IONGLOCException.IONGLOCSettingsException).cause
                     )
                 }
-                expectNoEvents()
+                awaitComplete()
             }
         }
 
@@ -580,9 +578,9 @@ class IONGLOCControllerTest {
                 every { time } returns currentTime
             }
 
-            // skip timeout in tests by calling internal method
-            sut.addWatchInternal(mockk<Activity>(), locationOptionsWithFallback, "1").test {
-                advanceUntilIdle()  // to wait until locationListenerCompat is instantiated
+            // call internal method to skip timeout
+            sut.watchLocationUpdatesFlow(locationOptionsWithFallback, "1").test {
+                advanceUntilIdle()
 
                 val result = awaitItem()
                 assertTrue(result.isSuccess)


### PR DESCRIPTION
## Description

This PR adds native timeout functionality to `watchPosition`. 

Also, in order to allow more configurability in `watchPosition`, allow to configure an `interval` parameter, instead of using just the `timeout`. By default `interval` is equal to `timeout`, to maintain backwards-compatible behavior.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4688

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Tests

Updated and added new unit tests to reflect the changes.

You may test with this sample Location App (updated 5 nov 2025) - [apk file](https://drive.google.com/file/d/1ke3BYasBjgEE97sLccf82z9sKh-JcezW/view?usp=sharing), or get [the source code](https://drive.google.com/file/d/1kHmH_tLqXek4oqILXpqNTWEL9rrIRfkL/view?usp=sharing) and build in Android Studio

## Checklist
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
